### PR TITLE
Add initial version of SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,21 @@
 # Reporting Security Issues
+
+This document outlines security procedures and general policies for public code repositories
+in the `transferwise/*` organization.
+
+## Reporting a vulnerability
+
+If you have found a security issue in one of our public repositories, we ask you to report it
+through our responsible disclosure program. You can find the full description of the program
+from [transferwise.com/responsible-disclosure](https://transferwise.com/responsible-disclosure).
+
+Your report will be triaged and responded to in Bugcrowd.
+
+### Alternative means of contact
+
+If you prefer to get in touch via e-mail, the contact details of our SOC are available
+from [transferwise.com/security.txt](https://transferwise.com/.well-known/security.txt).
+
+Note that direct reports over e-mail will not reach our managed bug bounty program and
+are not rewardable.
+


### PR DESCRIPTION
This will add a [default community health file](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) - `SECURITY.md` to all of our public repositories.

See [here](https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository) for examples how it will render in the UI.

We add it to make users of our code aware that we do have a channel to report issues to. We'll not mirror a separate policy text in GitHub, but rather point everyone to `/responsible-disclosure`.