### PR TITLE
[SO-1512] Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,10 @@
-## Description
+## Context
+<< Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. >>
 
-<< Please provide a description of your PR >>
-
-### Documentation Link(s)
-Jira Ticket: << Jira link >>
-
-Project Documentation: << E.g. Confluence page >>
+### Changes
+<< What changes have you made? Anything else we should keep in mind? >>
 
 ## Checklist
 - [ ] I have considered the impact of this change and added a [Change Classification](
-https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label
-- [ ] Change meets or does not compromise the [Security Baseline Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements)
+https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
+- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+
+<< Please provide a description of your PR >>
+
+### Documentation Link(s)
+Jira Ticket: << Jira link >>
+
+Project Documentation: << E.g. Confluence page >>
+
+## Checklist
+- [ ] I have considered the impact of this change and added a [Change Classification](
+https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label
+- [ ] Change meets or does not compromise the [Security Baseline Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
 ## Context
-<< Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. >>
+
+<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
 
 ### Changes
-<< What changes have you made? Anything else we should keep in mind? >>
+
+<!-- What changes have you made? Anything else we should keep in mind? -->
 
 ## Checklist
 - [ ] I have considered the impact of this change and added a [Change Classification](


### PR DESCRIPTION
This will add a default [community health file ](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file)- `PULL_REQUEST_TEMPLATE.md` to all of our repositories.

The intent is to provide a generic template that prompts for the required information/checks for each PR. 
Teams can (and should) add a `PULL_REQUEST_TEMPLATE.md` to their repos that meets their specific needs/use cases

The template aims to ensure we have:
- context around "why" a change is happening including link a Jira ticket and/or project documentation
- a description of the change
- a checklist item for change classification
- a checklist item for confirming the baseline security requirements