### PR TITLE
Remove 'Change classification' checkbox in favor of automated checks

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,5 @@
 
 <!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
 
-### Changes
-
-<!-- What changes have you made? Anything else we should keep in mind? -->
-
 ## Checklist
-- [ ] I have considered the impact of this change and added a [Change Classification](
-https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
 - [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


### PR DESCRIPTION
## Context

- Wise-github-bot is already taking care of this in form of an automated check. This is redundant now and unnecessary.

Closes #6

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
