### PR TITLE
Add Crowdin download workflow

### DIFF
--- a/workflow-templates/crowdin-download.yml
+++ b/workflow-templates/crowdin-download.yml
@@ -1,0 +1,55 @@
+name: Crowdin download
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+
+jobs:
+  download-from-crowdin:
+    runs-on: [self-hosted, production]
+    container: docker.tw.ee/actions_java15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get branch name
+        id: vars
+        run: echo ::set-output name=branch_name::${GITHUB_REF##*/}
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.3.1
+        with:
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_${{ steps.vars.outputs.branch_name }}
+          create_pull_request: true
+          pull_request_title: 'New or updated Crowdin translations'
+          pull_request_body: '## Context
+
+            Automated pull request pulling in new or updated translations from Crowdin
+
+            ## Checklist
+
+            - [x] I have considered the impact of this change and added a [Change Classification](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
+
+            - [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements)'
+          pull_request_labels: 'change:standard'
+          pull_request_base_branch_name: ${{ steps.vars.outputs.branch_name }}
+
+          # signing commits
+          gpg_private_key: ${{ secrets.GPG_SIGN_KEY }}
+          github_user_email: 'tw-actions@transferwise.com'
+
+          # integration settings
+          base_url: 'https://transferwise.crowdin.com'
+          crowdin_branch_name: ${{ steps.vars.outputs.branch_name }}
+          token: ${{ secrets.CROWDIN_ENTERPRISE_TOKEN }}
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }} # Add as repository secret — number from transferwise.crowdin.com project URL
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
This means we won't need to duplicate this file in every repo with l10n and we can centralise changes to it.

There's nothing project-specific other than the project id, which will be added via the `CROWDIN_PROJECT_ID` secret.

From:
https://transferwise.atlassian.net/wiki/spaces/TRAN/pages/1888527079/Moving+to+Crowdin+Enterprise

Confirmed to work in:
https://github.com/transferwise/pay-in
https://github.com/transferwise/account-details-bff

### Changes

A Crowdin download workflow is added.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
