### PR TITLE
Crowdin prune deleted branches

### DIFF
--- a/workflow-templates/crowdin-download.yml
+++ b/workflow-templates/crowdin-download.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo ::set-output name=branch_name::${GITHUB_REF##*/}
 
       - name: crowdin action
-        uses: crowdin/github-action@1.3.1
+        uses: crowdin/github-action@1.4.1
         with:
           upload_translations: false
           download_translations: true

--- a/workflow-templates/crowdin-prune-branch.yml
+++ b/workflow-templates/crowdin-prune-branch.yml
@@ -1,0 +1,23 @@
+name: Crowdin - prune deleted branch
+
+on:
+  delete
+
+jobs:
+  prune-branch-on-crowdin:
+    runs-on: [self-hosted, production]
+    container: docker.tw.ee/actions_java15
+
+    steps:
+      - name: crowdin action
+        uses: crowdin/github-action@1.3.1
+        with:
+          delete_crowdin_branch: ${{ github.event.ref }}
+          upload_sources: false
+          upload_translations: false
+          download_translations: false
+
+          # integration settings
+          base_url: 'https://transferwise.crowdin.com'
+          token: ${{ secrets.CROWDIN_ENTERPRISE_TOKEN }}
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }} # Add as repository secret — number from transferwise.crowdin.com project URL

--- a/workflow-templates/crowdin-prune-branch.yml
+++ b/workflow-templates/crowdin-prune-branch.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: crowdin action
-        uses: crowdin/github-action@1.3.1
+        uses: crowdin/github-action@1.4.1
         with:
           delete_crowdin_branch: ${{ github.event.ref }}
           upload_sources: false

--- a/workflow-templates/crowdin-upload.yml
+++ b/workflow-templates/crowdin-upload.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: crowdin action
-        uses: crowdin/github-action@1.3.1
+        uses: crowdin/github-action@1.4.1
         with:
           upload_sources: true
           upload_translations: false


### PR DESCRIPTION
## Context

Whenever we create a branch on Github, a matching branch/directory is created over on Crowdin Enterprise.

But when we _delete_ a branch on Github, nothing is automatically cleaned up on Crowdin Enterprise. This causes two problems:
- A lot of bloat over on Crowdin, as it becomes cluttered with lots of duplicate strings from very old branches. The interface becomes slower and more confusing for translators.
- The `crowdin-download` Action will continue to open lots of extraneous PRs from those old branches

This workflow fixes that.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
