### PR TITLE
Crowdin should always operate on main or master branches by default

### DIFF
--- a/workflow-templates/crowdin-download.yml
+++ b/workflow-templates/crowdin-download.yml
@@ -5,9 +5,9 @@ on:
     - cron: '0 7 * * 1-5'
   workflow_dispatch:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'dependabot-**'
+    branches:
+      - main
+      - master
 
 jobs:
   download-from-crowdin:

--- a/workflow-templates/crowdin-upload.yml
+++ b/workflow-templates/crowdin-upload.yml
@@ -2,9 +2,9 @@ name: Crowdin upload
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'dependabot-**'
+    branches:
+      - main
+      - master
 
 jobs:
   upload-to-crowdin:


### PR DESCRIPTION
## Context

It's a very specific usecase for any service to want to have all branches scanned and translated. It means a lot of overhead for translators, a lot more mess on crowdin and branches to cleanup after on github, many many more open PRs opened by crowdin, and a general mess to manage all of this crowdin stuff.

While I understand there is a usecase for such a setup, I don't think this should be the default setup at all. Instead the default should be that only main/master branches gets any crowdin work at all.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
