### PR TITLE
Update crowdin/github-action version

### DIFF
--- a/workflow-templates/crowdin-download.yml
+++ b/workflow-templates/crowdin-download.yml
@@ -12,18 +12,18 @@ on:
 jobs:
   download-from-crowdin:
     runs-on: [self-hosted, production, medium]
-    container: docker.tw.ee/actions_java15
+    container: docker.tw.ee/actions_java17
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get branch name
         id: vars
         run: echo ::set-output name=branch_name::${GITHUB_REF##*/}
 
       - name: crowdin action
-        uses: crowdin/github-action@1.3.1
+        uses: crowdin/github-action@v1
         with:
           upload_translations: false
           download_translations: true

--- a/workflow-templates/crowdin-upload.yml
+++ b/workflow-templates/crowdin-upload.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   upload-to-crowdin:
     runs-on: [self-hosted, production]
-    container: docker.tw.ee/actions_java15
+    container: docker.tw.ee/actions_java17
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: crowdin action
-        uses: crowdin/github-action@1.3.1
+        uses: crowdin/github-action@v1
         with:
           upload_sources: true
           upload_translations: false


### PR DESCRIPTION
## Context

I encountered a [problem on error-pages](https://github.com/transferwise/error-pages/pull/1008) with the crowdin-download script that was solved by simply updating the github-actions action. 

It seems beneficial to keep the action (and by extension the crowdin CLI version) up to date.

I have removed the minor version pin so it just pulls the latest minor version that is major version 1.

Also updates java->17 and github/checkout action.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
