### PR TITLE
remove unneeded condition for workflow trigger on failure as the trigger has already been removed

### DIFF
--- a/workflow-templates/call-ci-ai-agents.yml
+++ b/workflow-templates/call-ci-ai-agents.yml
@@ -16,8 +16,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/run-ci-ai-agents')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/run-ci-ai-agents')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/run-ci-ai-agents')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '/run-ci-ai-agents') || contains(github.event.issue.title, '/run-ci-ai-agents'))) ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '/run-ci-ai-agents') || contains(github.event.issue.title, '/run-ci-ai-agents')))
     uses: transferwise/.github/.github/workflows/reusable-workflow-ci-ai-agents.yaml@master
     secrets: inherit
     with:


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

remove unneeded condition for workflow trigger on failure as the trigger has already been removed

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
