### PR TITLE
NO-JIRA - add pull_request event to reusable ci ai agents workflow

### DIFF
--- a/.github/workflows/reusable-workflow-ci-ai-agents.yaml
+++ b/.github/workflows/reusable-workflow-ci-ai-agents.yaml
@@ -54,6 +54,7 @@ jobs:
     if: |
       inputs.event_name == 'issues' ||
       inputs.event_name == 'issue_comment' ||
+      inputs.event_name == 'pull_request' ||
       inputs.event_name == 'pull_request_review_comment' ||
       inputs.event_name == 'pull_request_review'
     runs-on: gha-production-medium


### PR DESCRIPTION
## Context

The reusable workflow reusable-workflow-ci-ai-agents.yaml did not handle the `pull_request` event in its `run-ci-ai-agent` job condition. When a caller workflow triggered it with `event_name: pull_request` (e.g., on PR opened or converted from draft), the job was skipped because `pull_request` was not in the allowed event names list.

This adds `inputs.event_name == 'pull_request'` to the job's `if` condition.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements)